### PR TITLE
fix: removed left and right margin from hero image at max breakpoint

### DIFF
--- a/client/src/components/Carousel/carousel.styles.js
+++ b/client/src/components/Carousel/carousel.styles.js
@@ -9,10 +9,6 @@ const CarouselContainer = styled.div`
   ${mq[2]} {
     display: block;
   }
-
-  ${mq[6]} {
-    margin: 0 var(--spacing-04);
-  }
 `;
 
 const CarouselSlideList = styled.ul`


### PR DESCRIPTION
fix: Carousel component's hero image stretches to max breakpoint now. #64 